### PR TITLE
Removed missing source files from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,9 @@ add_library(util STATIC
     src/bit.s
     src/debug.s
     src/log.c
-    src/mem.s
     src/profile.s
     src/rand.s
     src/simd.s
-    src/str.s
 )
 
 target_include_directories(util PUBLIC include/)


### PR DESCRIPTION
The original `CMakeLists.txt` refers to two source files which have not been pushed by the author.
As the `meson.build` does not mention them, this seems intentional.